### PR TITLE
Add config option to multiply EMC transmutation energy cost

### DIFF
--- a/src/main/java/gripe/_90/appliede/AppliedEConfig.java
+++ b/src/main/java/gripe/_90/appliede/AppliedEConfig.java
@@ -13,6 +13,7 @@ public class AppliedEConfig {
     }
 
     private final ForgeConfigSpec.DoubleValue moduleEnergyUsage;
+    private final ForgeConfigSpec.DoubleValue transmutationPowerMultiplier;
     private final ForgeConfigSpec.IntValue emcPerByte;
     private final ForgeConfigSpec.BooleanValue terminalExtractFromOwnEmcOnly;
     private final ForgeConfigSpec.IntValue syncThrottleInterval;
@@ -20,6 +21,9 @@ public class AppliedEConfig {
     private AppliedEConfig(ForgeConfigSpec.Builder builder) {
         moduleEnergyUsage = builder.comment("The amount of AE energy per tick used by the ME Transmutation Module.")
                 .defineInRange("moduleEnergyUsage", 25.0, 0, Double.MAX_VALUE);
+        transmutationPowerMultiplier = builder.comment(
+                        "The amount of AE energy used to transmute 1 EMC through the ME Transmutation Module.")
+                .defineInRange("transmutationPowerMultiplier", 1.0, 0, Double.MAX_VALUE);
         emcPerByte = builder.comment(
                         "The number of EMC units (of any tier) per byte as used in AE2 auto-crafting.",
                         "It is not recommended to set this very low as this will require unreasonably large",
@@ -37,6 +41,10 @@ public class AppliedEConfig {
 
     public double getModuleEnergyUsage() {
         return moduleEnergyUsage.get();
+    }
+
+    public double getTransmutationPowerMultiplier() {
+        return transmutationPowerMultiplier.get();
     }
 
     public int getEmcPerByte() {

--- a/src/main/java/gripe/_90/appliede/me/service/EMCStorage.java
+++ b/src/main/java/gripe/_90/appliede/me/service/EMCStorage.java
@@ -322,7 +322,8 @@ public final class EMCStorage implements MEStorage {
 
     private long getAmountAfterPowerExpenditure(BigInteger maxEmc, BigInteger itemEmc) {
         var energyService = service.getGrid().getEnergyService();
-        var multiplier = BigDecimal.valueOf(PowerMultiplier.CONFIG.multiplier);
+        var multiplier = BigDecimal.valueOf(PowerMultiplier.CONFIG.multiplier)
+                .multiply(BigDecimal.valueOf(AppliedEConfig.CONFIG.getTransmutationPowerMultiplier()));
         var toExpend = new BigDecimal(maxEmc).multiply(multiplier).min(BigDecimal.valueOf(Double.MAX_VALUE));
 
         var available = energyService.extractAEPower(toExpend.doubleValue(), Actionable.SIMULATE, PowerMultiplier.ONE);


### PR DESCRIPTION
Fixes #20.

My testing indicates the new config option works as expected.
With `transmutationPowerMultiplier` set to 0.0, one can transmute as much as they want without spending any additional energy besides the passive drain from the module.
With `transmutationPowerMultiplier` set to 1.0, its as if nothing changed.
With `transmutationPowerMultiplier` set to something large like `9999999999999999999999`, transmuting a single piece of cobblestone drains all energy stored in the ME network.
With, `transmutationPowerMultiplier` set to 0.0005, transmuting EMC and charging Klein Stars both cost the same amount of energy (this may be a good lower limit if 0 isn't). Anything lower and the energy cost to charge a Klein Star exceeds the energy cost to transmute the same amount of EMC on items.
With `transmutationPowerMultiplier` set to 0.000001 and Project Expansion installed, transmuting a Fading Matter (worth a trillion EMC) only costs around 2 million FE instead of 2 trillion FE. Lower values reduce this cost.

As this is part of the common config (like the other config options), a full restart of the client and server is required to apply any changes.