### PR TITLE
Fix transmutation pattern equality for EMC tier patterns

### DIFF
--- a/src/main/java/gripe/_90/appliede/me/service/TransmutationPattern.java
+++ b/src/main/java/gripe/_90/appliede/me/service/TransmutationPattern.java
@@ -89,7 +89,7 @@ public final class TransmutationPattern implements IPatternDetails {
     @Override
     public boolean equals(Object obj) {
         return obj instanceof TransmutationPattern pattern
-                && pattern.output.equals(output)
+                && Objects.equals(pattern.output, output)
                 && pattern.amount == amount
                 && pattern.tier == tier
                 && pattern.job == job;


### PR DESCRIPTION
This fixes a server crash when AE2 compares an AppliedE transmutation pattern against one of the EMC tier patterns. Those tier patterns intentionally have no item output, so `equals` could hit a null output while AE2 was mounting crafting providers.

`hashCode` already includes the same nullable field through `Objects.hash`, so using `Objects.equals` keeps the equality check consistent while allowing the tier patterns to be compared safely.